### PR TITLE
Utilize docker init

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.2'
 
 networks:
   nexus-net:
@@ -16,6 +16,7 @@ services:
   nexus:
     container_name: nexus
     image: sonatype/nexus3
+    init: true
     networks:
       - nexus-net
     volumes:
@@ -24,6 +25,7 @@ services:
   nginx-proxy:
     container_name: nexus-nginx-proxy
     image: nginx
+    init: true
     networks:
       - nexus-net
     links:
@@ -40,6 +42,7 @@ services:
   manage-nexus:
     container_name: nexus-manage
     build: ./nexus/
+    init: true
     image: nexus/manage
     networks:
       - nexus-net


### PR DESCRIPTION
Newer specification of docker-compose supports enabling init for the containers.  This is important for long running containers like Nexus.

Refer to [docker-compose documentation for the `init`][1] option.

There's a lot of articles about why an init process in a container is important.  Here's a few key references.

- http://phusion.github.io/baseimage-docker/
- https://engineeringblog.yelp.com/2016/01/dumb-init-an-init-for-docker.html
- https://docs.docker.com/engine/admin/multi-service_container/

[1]: https://docs.docker.com/compose/compose-file/compose-file-v2/#init